### PR TITLE
minor changes, add secret sad reacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ Features
 Build & Run
 -----------
 
-See [doc/Install.md](doc/Install.md) for details on build / install.
-
+See [doc/admin.rst#installing-from-source](doc/admin.rst#installing-from-source) for details on build / install.
 
 Plugin API
 ----------

--- a/doc/admin.rst
+++ b/doc/admin.rst
@@ -62,7 +62,7 @@ project:
 .. code:: bash
 
     # creates a build directory named "build"
-    meson build
+    meson setup build
     # change to "build" and compile everything
     ninja -C build
 

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ libircclient_dep = dependency(
   fallback: ['libircclient', 'libircclient_dep'],
   # There are some compiler warnings, silence them
   default_options: [
-    'libircclient:warning_level=0',
+    'warning_level=0',
   ],
 )
 libsc_regex_dep = dependency(

--- a/plugin/trivia.c
+++ b/plugin/trivia.c
@@ -53,6 +53,8 @@ static const char *sad_reacts[] = {
 	"😥",
 	"😢",
 	"😭",
+	"😔",
+	"😩",
 };
 
 static const char *plus_reacts[] = {

--- a/sample.cfg
+++ b/sample.cfg
@@ -107,7 +107,7 @@ plugins: {
         addressed = true;
         responses = [
           ":(",
-          "I don't like you, {sender}",
+          "I don't like you, {sender}"
         ];
       }
     );


### PR DESCRIPTION
last week I really wanted to react with 'pensive' but it was not on the authoritative list. I'm on the fence about adding the two new emojis to the reminder message because I don't want to bloat it, and I don't think people will use either of these to respond affirmatively, but up to you.

on a debian container I did need a few extra deps but I assume they're just included with ubuntu. the `sample.cfg` thing I noticed was handled by some libconfig libraries but not others